### PR TITLE
bugfix: "Uncaught exception: unexpected return in method ..."

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -31,7 +31,7 @@ Add this code to your controller:
     exposes_xmlrpc_methods
     
     add_method 'Container.method_name' do
-      return 'Hello World'
+      'Hello World'
     end
 
   end


### PR DESCRIPTION
Broken usage example from readme (I don't know why it happens):

```
$ rails -v
Rails 3.2.13
$ ruby -v
ruby 1.9.3p392 (2013-02-22 revision 39386) [x86_64-linux]

Adding XMLRPC method for Container.method_name
Adding XMLRPC method for _one_time_conditions_valid_24?
Adding XMLRPC method for xe_method_prefix
Adding XMLRPC method for _run__1132595195784790462__process_action__1603923443666658497__callbacks


----- BEGIN RESULT -----
<?xml version="1.0" ?><methodResponse><fault><value><struct><member><name>faultCode</name><value><i4>2</i4></value></member><member><name>faultString</name><value><string>Uncaught exception unexpected return in method Container.method_name</string></value></member></struct></value></fault></methodResponse>
----- END RESULT -----



Started POST "/RPC2/" for 127.0.0.1 at 2013-04-22 19:22:58 +0400
Processing by RpcApiController#xe_index as */*
  Parameters: {"methodCall"=>{"methodName"=>"Container.method_name", "params"=>"\n"}}
WARNING: Can't verify CSRF token authenticity
  Rendered text template (0.0ms)
Completed 200 OK in 7ms (Views: 0.4ms | ActiveRecord: 0.0ms)
```
